### PR TITLE
Update create-datablocks.markdown

### DIFF
--- a/create-datablocks.markdown
+++ b/create-datablocks.markdown
@@ -66,9 +66,11 @@ In this section we show you how you can start using the new disk.
 ```sh
 mkdir /data  
 mkfs -t xfs /dev/vdb  
-mount /dev/vdb /data  
+mount /dev/vdb /data
+touch /etc/rc.d/rc.local
+echo "echo 4096 > /sys/block/vdb/queue/read_ahead_kb" > /etc/rc.d/rc.local
+chmod 755 /etc/rc.d/rc.local
 ```
-
 >**NOTE:**
 >
 >The first two commands only need to be run once (and destroy everything on your disk!). The mount command (third one) needs to be run every time you start the image or you can add this line to /etc/fstab to be done automatically: `/dev/vdb /data xfs defaults 0 0`. 


### PR DESCRIPTION
added 4MB read_ahead_kb settings for optimal ceph performance
