### PR TITLE
Update booting options in the template.

### DIFF
--- a/vm-scratch-centos.markdown
+++ b/vm-scratch-centos.markdown
@@ -72,9 +72,9 @@ Now that we have all components ready in the UI, we are ready to bring them toge
 4. **On the UI:** On the same _Create VM Template_ screen, on the _Network_ tab:
   * for the _Interface 0_ (on the left column of the screen), choose the **internet** `network` (from the table on the right of the screen)
   * click on the _+_ button (that will make a new _Interface 1_), and then choose your internal `network` (it will be the only other `network ` that you can see on the right that is not called **internet**)
-5.  **On the UI:** On the same _Create VM Template_ screen, on the _OS Booting_ tab (note! use the following boot order, otherwise, changes are not saved due to a bug in opennebula):
-  * for the _1st Boot_ field, **choose _HD_**
-  * for the _2nd Boot_ field, **choose _CDROM_** 
+5.  **On the UI:** On the same _Create VM Template_ screen, on the _OS Booting_ tab:
+  * for the _1st Boot_ field, **choose _centos_iso_**
+  * for the _2nd Boot_ field, **choose _centos_drive_** 
 6.  **On the UI:** On the same _Create VM Template_ screen, on the _Input/Output_ tab:
   * click on the _VNC_ radio button
   * on the _Inputs group_, choose _Tablet_ on the first dropdown menu, then _USB_ on the second dropdown menu and finally click on the _Add_ button. A new entry will appear below those dropdowns with what you just selected.


### PR DESCRIPTION
Following instructions did not work. The image failed to boot.
Changing Boot order to:
first: centos_iso
second: centos_drive
solved an issue